### PR TITLE
✨ GASのV8ランタイムで動作するように修正 #5

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -1,14 +1,14 @@
 {
   "timeZone": "Asia/Tokyo",
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
   "dependencies": {
     "libraries": [
       {
-        "userSymbol": "TwitterWebService",
-        "version": "2",
-        "libraryId": "1rgo8rXsxi1DxI_5Xgo_t3irTw1Y5cxl2mGSkbozKsSXf2E_KBBPC3xTF"
+        "userSymbol": "OAuth1",
+        "version": "18",
+        "libraryId": "1CXDCY5sqT9ph64fFwSzVtXnbjpSfWdRymafDrtIZ7Z_hwysTY7IIhi7s"
       }
     ]
-  },
-  "exceptionLogging": "STACKDRIVER",
-  "runtimeVersion": "V8"
+  }
 }

--- a/src/libs/twitter.js
+++ b/src/libs/twitter.js
@@ -1,7 +1,53 @@
+function getInstance(consumer_key, consumer_secret) {
+  return new TwitterWebService(consumer_key, consumer_secret);
+}
+
+var TwitterWebService = function (consumer_key, consumer_secret) {
+  this.consumer_key    = consumer_key;
+  this.consumer_secret = consumer_secret;
+}
+
+TwitterWebService.prototype.getService = function() {
+  return OAuth1.createService('Twitter')
+    .setAccessTokenUrl('https://api.twitter.com/oauth/access_token')
+    .setRequestTokenUrl('https://api.twitter.com/oauth/request_token')
+    .setAuthorizationUrl('https://api.twitter.com/oauth/authorize')
+    .setConsumerKey(this.consumer_key)
+    .setConsumerSecret(this.consumer_secret)
+    .setCallbackFunction('authCallback')
+    .setPropertyStore(PropertiesService.getUserProperties())
+}
+
+TwitterWebService.prototype.authorize = function() {
+  var service = this.getService();
+  if (service.hasAccess()) {
+    Logger.log('Already authorized');
+  } else {
+    var authorizationUrl = service.authorize();
+    Logger.log('Open the following URL and re-run the script: %s', authorizationUrl);
+  }
+}
+
+TwitterWebService.prototype.reset = function() {
+  var service = this.getService();
+  service.reset();
+}
+
+TwitterWebService.prototype.authCallback = function(request) {
+  var service      = this.getService();
+  var isAuthorized = service.handleCallback(request);
+  var mimeType     = ContentService.MimeType.TEXT;
+  if (isAuthorized) {
+    return ContentService.createTextOutput('Success').setMimeType(mimeType);
+  } else {
+    return ContentService.createTextOutput('Denied').setMimeType(mimeType);
+  }
+}
+
 /**
  * @type {Object} OAuth1認証用インスタンス。プロパティはGASの画面から設定が必要。
  */
-const twitter = TwitterWebService.getInstance(
+const twitter = getInstance(
     PropertiesService.getScriptProperties().getProperty('TWITTER_API_KEY'),
     PropertiesService.getScriptProperties().getProperty('TWITTER_API_SECRET'),
 );
@@ -51,7 +97,7 @@ function twitterReset() {
  * @param {Object} request
  * @return {Object}
  */
-function twitterAuthCallback(request) {
+function authCallback(request) {
   return twitter.authCallback(request);
 }
 

--- a/src/libs/twitter.js
+++ b/src/libs/twitter.js
@@ -2,47 +2,47 @@ function getInstance(consumer_key, consumer_secret) {
   return new TwitterWebService(consumer_key, consumer_secret);
 }
 
-var TwitterWebService = function (consumer_key, consumer_secret) {
-  this.consumer_key    = consumer_key;
+var TwitterWebService = function(consumer_key, consumer_secret) {
+  this.consumer_key = consumer_key;
   this.consumer_secret = consumer_secret;
-}
+};
 
 TwitterWebService.prototype.getService = function() {
   return OAuth1.createService('Twitter')
-    .setAccessTokenUrl('https://api.twitter.com/oauth/access_token')
-    .setRequestTokenUrl('https://api.twitter.com/oauth/request_token')
-    .setAuthorizationUrl('https://api.twitter.com/oauth/authorize')
-    .setConsumerKey(this.consumer_key)
-    .setConsumerSecret(this.consumer_secret)
-    .setCallbackFunction('authCallback')
-    .setPropertyStore(PropertiesService.getUserProperties())
-}
+      .setAccessTokenUrl('https://api.twitter.com/oauth/access_token')
+      .setRequestTokenUrl('https://api.twitter.com/oauth/request_token')
+      .setAuthorizationUrl('https://api.twitter.com/oauth/authorize')
+      .setConsumerKey(this.consumer_key)
+      .setConsumerSecret(this.consumer_secret)
+      .setCallbackFunction('authCallback')
+      .setPropertyStore(PropertiesService.getUserProperties());
+};
 
 TwitterWebService.prototype.authorize = function() {
-  var service = this.getService();
+  const service = this.getService();
   if (service.hasAccess()) {
     Logger.log('Already authorized');
   } else {
-    var authorizationUrl = service.authorize();
+    const authorizationUrl = service.authorize();
     Logger.log('Open the following URL and re-run the script: %s', authorizationUrl);
   }
-}
+};
 
 TwitterWebService.prototype.reset = function() {
-  var service = this.getService();
+  const service = this.getService();
   service.reset();
-}
+};
 
 TwitterWebService.prototype.authCallback = function(request) {
-  var service      = this.getService();
-  var isAuthorized = service.handleCallback(request);
-  var mimeType     = ContentService.MimeType.TEXT;
+  const service = this.getService();
+  const isAuthorized = service.handleCallback(request);
+  const mimeType = ContentService.MimeType.TEXT;
   if (isAuthorized) {
     return ContentService.createTextOutput('Success').setMimeType(mimeType);
   } else {
     return ContentService.createTextOutput('Denied').setMimeType(mimeType);
   }
-}
+};
 
 /**
  * @type {Object} OAuth1認証用インスタンス。プロパティはGASの画面から設定が必要。

--- a/src/libs/twitter.js
+++ b/src/libs/twitter.js
@@ -1,3 +1,9 @@
+/**
+ * TwitterWebServiceのインスタンスを生成して返す。
+ * @param {String} consumer_key TwitterのAPI key
+ * @param {String} consumer_secret TwitterのAPI secret key
+ * @return {TwitterWebService}
+ */
 function getInstance(consumer_key, consumer_secret) {
   return new TwitterWebService(consumer_key, consumer_secret);
 }

--- a/src/libs/twitter.js
+++ b/src/libs/twitter.js
@@ -8,7 +8,7 @@ function getInstance(consumer_key, consumer_secret) {
   return new TwitterWebService(consumer_key, consumer_secret);
 }
 
-let TwitterWebService = function(consumer_key, consumer_secret) {
+const TwitterWebService = function(consumer_key, consumer_secret) {
   this.consumer_key = consumer_key;
   this.consumer_secret = consumer_secret;
 };
@@ -30,7 +30,8 @@ TwitterWebService.prototype.authorize = function() {
     Logger.log('Already authorized');
   } else {
     const authorizationUrl = service.authorize();
-    Logger.log('Open the following URL and re-run the script: %s', authorizationUrl);
+    Logger.log('Open the following URL and re-run the script: %s',
+        authorizationUrl);
   }
 };
 

--- a/src/libs/twitter.js
+++ b/src/libs/twitter.js
@@ -8,7 +8,7 @@ function getInstance(consumer_key, consumer_secret) {
   return new TwitterWebService(consumer_key, consumer_secret);
 }
 
-var TwitterWebService = function(consumer_key, consumer_secret) {
+let TwitterWebService = function(consumer_key, consumer_secret) {
   this.consumer_key = consumer_key;
   this.consumer_secret = consumer_secret;
 };

--- a/src/libs/twitter.js
+++ b/src/libs/twitter.js
@@ -1,16 +1,16 @@
 /**
  * TwitterWebServiceのインスタンスを生成して返す。
- * @param {String} consumer_key TwitterのAPI key
- * @param {String} consumer_secret TwitterのAPI secret key
+ * @param {String} consumerKey TwitterのAPI key
+ * @param {String} consumerSecret TwitterのAPI secret key
  * @return {TwitterWebService}
  */
-function getInstance(consumer_key, consumer_secret) {
-  return new TwitterWebService(consumer_key, consumer_secret);
+function getInstance(consumerKey, consumerSecret) {
+  return new TwitterWebService(consumerKey, consumerSecret);
 }
 
-const TwitterWebService = function(consumer_key, consumer_secret) {
-  this.consumer_key = consumer_key;
-  this.consumer_secret = consumer_secret;
+const TwitterWebService = function(consumerKey, consumerSecret) {
+  this.consumerKey = consumerKey;
+  this.consumerSecret = consumerSecret;
 };
 
 TwitterWebService.prototype.getService = function() {
@@ -18,8 +18,8 @@ TwitterWebService.prototype.getService = function() {
       .setAccessTokenUrl('https://api.twitter.com/oauth/access_token')
       .setRequestTokenUrl('https://api.twitter.com/oauth/request_token')
       .setAuthorizationUrl('https://api.twitter.com/oauth/authorize')
-      .setConsumerKey(this.consumer_key)
-      .setConsumerSecret(this.consumer_secret)
+      .setConsumerKey(this.consumerKey)
+      .setConsumerSecret(this.consumerSecret)
       .setCallbackFunction('authCallback')
       .setPropertyStore(PropertiesService.getUserProperties());
 };

--- a/src/variables.js
+++ b/src/variables.js
@@ -16,3 +16,12 @@ const userName = props.getProperty('USER_NAME');
  * @type {String}
  */
 const twitterUserId = props.getProperty('TWITTER_USER_ID');
+
+function setProperties() {
+  props.setProperty('WEATHER_SEARCH_CITY', '');
+  props.setProperty('WEATHER_SEARCH_COUNTRY', '');
+  props.setProperty('USER_NAME', '');
+  props.setProperty('OPEN_WEATHER_MAP_API_KEY', '');
+  props.setProperty('TWITTER_API_KEY', '');
+  props.setProperty('TWITTER_API_SECRET', '');
+}

--- a/src/variables.js
+++ b/src/variables.js
@@ -17,6 +17,11 @@ const userName = props.getProperty('USER_NAME');
  */
 const twitterUserId = props.getProperty('TWITTER_USER_ID');
 
+/**
+ * スクリプトプロパティを更新する。
+ * AppsScriptのUI上でスクリプトプロパティを更新できなくなったため
+ * プロパティを更新したいときだけ以下の設定値を書き換えて手動実行する。
+ */
 function setProperties() {
   props.setProperty('WEATHER_SEARCH_CITY', '');
   props.setProperty('WEATHER_SEARCH_COUNTRY', '');


### PR DESCRIPTION
close #5 

## 起きてた問題

### TwitterWebServiceライブラリがGASのV8ランタイムに対応していない

#### 内容

- 結果として、V8ランタイムでTwitterWebServiceを実行しようとするとエラーになる
- TwitterWebServiceの更新は現在止まっている
- Webにある記事のほとんどは「V8ランタイムを無効化すればOK」という内容ばかり

#### 解決方法

- [TwitterWebService](https://script.google.com/home/projects/1rgo8rXsxi1DxI_5Xgo_t3irTw1Y5cxl2mGSkbozKsSXf2E_KBBPC3xTF/edit)のコードを取得してこのプロジェクトにコピー
- 変数・関数名を微調整
- AppsScriptのライブラリに OAuth1 のバージョン 18 を追加

### AppsScriptの新UI上でプロパティが設定できない

#### 内容

- 以前のAppsScriptでは、UI上でプロパティを設定できていたが、現在できなくなっている
  - `PropertiesService.getScriptProperties().getProperty('TWITTER_API_KEY')` とかでアクセスできるプロパティのこと

#### 解決方法

- プロパティを更新したい時だけ手動実行する`setProperties`という関数を追加した
  - 更新するときだけソースコードを書き換えて実行する

以上